### PR TITLE
chore: bump Node.js to 24 and modernize CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,29 +5,22 @@ name: main
 on: [push]
 
 env:
-  NODE_VERSION: '22.x'
+  NODE_VERSION: '24.x'
 
 jobs:
   continuous_integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
-        run: npm install -g pnpm --registry=https://registry.npmjs.org
+        uses: pnpm/action-setup@v6
 
-      - name: Get pnpm cache directory
-        uses: actions/cache@v4
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v7
         with:
-          path: ~/.local/share/pnpm/store
-          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install
@@ -46,7 +39,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://simrobin.fr",
   "packageManager": "pnpm@10.29.3",
   "engines": {
-    "node": "=22",
+    "node": "=24",
     "pnpm": "=10"
   },
   "scripts": {


### PR DESCRIPTION
## Changements

- **Node 22 → 24** (LTS courant) : `engines.node` dans `package.json` + `NODE_VERSION` dans le workflow CI.
- **pnpm via `pnpm/action-setup@v6`** : respecte le champ `packageManager` (avant : `npm install -g pnpm` qui installait la dernière version, sans lien avec celle du projet).
- **Cache pnpm natif de `setup-node`** : remplace le step `actions/cache` manuel.
- **Bump des actions** : `checkout@v7`, `setup-node@v7`, `upload-artifact@v7` (les v4 tournent sur le runtime Node 20 déprécié des runners).

## Note Vercel

Vercel lit `engines.node` pour choisir la version de build. Vérifier dans le dashboard (Settings → Build & Development) que la version Node est en auto-detect ou passée à 24.