### PR TITLE
chore: bump pnpm to 11 and migrate config to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,0 @@
-funds=false
-audit=false
-legacy-peer-deps=true
-npm_config_loglevel=error
-minimum-release-age=10080

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "url": "git+https://github.com/simrobin/about.git"
   },
   "homepage": "https://simrobin.fr",
-  "packageManager": "pnpm@10.29.3",
+  "packageManager": "pnpm@11.16.0",
   "engines": {
     "node": "=24",
-    "pnpm": "=10"
+    "pnpm": "=11"
   },
   "scripts": {
     "dev": "astro dev",
@@ -43,15 +43,6 @@
     "@pandacss/postcss": "^1.11.3",
     "@playwright/test": "1.60.0",
     "typescript": "6.0.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "sharp"],
-    "overrides": {
-      "picomatch@>=4.0.0 <4.0.4": "4.0.4",
-      "yaml@>=2.0.0 <2.8.3": "2.8.3",
-      "tar": ">=7.5.11",
-      "undici": ">=7.24.0"
-    }
   },
   "license": "ISC"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: true
+  sharp: true
+
+minimumReleaseAge: 10080
+
+overrides:
+  'picomatch@>=4.0.0 <4.0.4': 4.0.4
+  'yaml@>=2.0.0 <2.8.3': 2.8.3
+  tar: '>=7.5.11'
+  undici: '>=7.24.0'


### PR DESCRIPTION
## Changements

- **pnpm 10.29.3 → 11.16.0** : `packageManager` + `engines.pnpm` (=11). Version choisie = dernière release plus vieille que la fenêtre `minimumReleaseAge` de 7 jours (11.17/11.18 trop récentes).
- **Migration config** (pnpm 11 ne lit plus `.npmrc` ni le bloc `package.json#pnpm`) :
  - `minimumReleaseAge: 10080` → `pnpm-workspace.yaml` (depuis `.npmrc`)
  - `overrides` → `pnpm-workspace.yaml` (depuis `package.json`)
  - `onlyBuiltDependencies` → nouvelle map `allowBuilds` (esbuild ✅, sharp ✅, @parcel/watcher ❌ — parité exacte avec le comportement pnpm 10)
  - `.npmrc` supprimé (les clés restantes étaient npm-only ou invalides)

## Garanties

- **Lockfile inchangé** : audit avant/après des 763 versions résolues, 0 ajoutée, 0 supprimée. `pnpm install --frozen-lockfile` no-op.
- Lint, typecheck, build verts en local sous pnpm 11.
- La CI installe pnpm via `pnpm/action-setup@v6` qui lit `packageManager` → prendra 11.16.0 automatiquement.