### PR TITLE
ci: track GitHub Actions updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,16 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Ajoute l'ecosystem `github-actions` à la config Dependabot pour que les versions des actions du workflow restent à jour sans passage manuel.

Groupées en une seule PR hebdomadaire (`patterns: ['*']`) pour éviter une PR par action. Préfixe de commit `ci` pour les distinguer des bumps npm.