### PR TITLE
fix(security): raise @hono/node-server override to 2.0.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@hono/node-server@<2.0.5': 2.0.5
+  '@hono/node-server@<2.0.11': 2.0.11
   brace-expansion@>=5.0.0 <5.0.7: 5.0.7
   fast-uri@>=3.0.0 <3.1.4: 3.1.4
   hono@>=4.0.0 <4.12.27: 4.12.27
@@ -704,8 +704,8 @@ packages:
   '@fontsource-variable/montserrat@5.3.0':
     resolution: {integrity: sha512-7PaZoxaxrWLAyrhO46v65An9LhUhfkTExWLhfbywYZCnZEgg/W1rEHnlNmZKjNZ3nJTVYyicqxlJt10z/26yTA==}
 
-  '@hono/node-server@2.0.5':
-    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: 4.12.27
@@ -3844,7 +3844,7 @@ snapshots:
 
   '@fontsource-variable/montserrat@5.3.0': {}
 
-  '@hono/node-server@2.0.5(hono@4.12.27)':
+  '@hono/node-server@2.0.11(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -3999,7 +3999,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.5(hono@4.12.27)
+      '@hono/node-server': 2.0.11(hono@4.12.27)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ allowBuilds:
 minimumReleaseAge: 10080
 
 overrides:
-  '@hono/node-server@<2.0.5': 2.0.5
+  '@hono/node-server@<2.0.11': 2.0.11
   'brace-expansion@>=5.0.0 <5.0.7': 5.0.7
   'fast-uri@>=3.0.0 <3.1.4': 3.1.4
   'hono@>=4.0.0 <4.12.27': 4.12.27


### PR DESCRIPTION
Ferme la dernière alerte Dependabot ouverte.

Un nouvel avis couvre toute la plage `>= 2.0.0, <= 2.0.9` (DoS par fuite mémoire non authentifiée via handshake WebSocket avorté) : le pin à 2.0.5 posé lors de la passe précédente est donc lui-même vulnérable.

2.0.11 est hors plage et publiée depuis plus de 7 jours (2.0.12 est trop récente pour `minimumReleaseAge`). L'avis ne déclare aucune `first_patched_version`, la version a été choisie en sortant manuellement de la plage vulnérable.

Dépendance dev-only, atteinte via le serveur MCP de `@pandacss/dev`.

Build, typecheck et les 11 tests Playwright passent.