### PR TITLE
fix(build): run panda codegen as part of the build script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,15 @@ Personal portfolio/CV website for Simon Robin (simrobin.fr). Content is in Frenc
 ## Commands
 
 - **Dev server:** `pnpm start` or `pnpm dev`
-- **Build:** `pnpm build`
+- **Build:** `pnpm build` (runs `panda codegen` first, see below)
 - **Preview:** `pnpm preview`
 - **Lint & format:** `pnpm lint` (runs biome check --fix on src/)
 - **Format only:** `pnpm format` (runs biome format --write on src/)
 - **Tests:** `pnpm test` (Playwright E2E)
 - **Update snapshots:** `pnpm test:update` (after intentional visual changes)
-- **Panda codegen:** `pnpm prepare` (runs automatically after install)
+- **Panda codegen:** `pnpm prepare` (also runs after a fresh install)
+
+`styled-system/` is gitignored, so `build` regenerates it rather than trusting `prepare` to have run. pnpm 11 skips lifecycle scripts when an install has nothing to do, and Vercel restores `node_modules` from its build cache : without this, any commit that changes neither `package.json` nor the lockfile deploys with `styled-system/` missing and fails to resolve `../../styled-system/css`.
 
 ## Tech Stack
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "panda codegen && astro build",
     "preview": "astro preview",
     "lint": "biome check --fix src/",
     "lint:file": "biome check --fix",


### PR DESCRIPTION
## Le problème

Deux déploiements production ont échoué sur `Could not resolve '../../styled-system/css'" : #585 (dependabot.yml seul) et #588 (CLAUDE.md seul). Ce n'est pas du flaky, c'est déterministe.

## Cause racine

`styled-system/` est gitignoré et produit uniquement par le script `prepare`. Or **pnpm 11 a changé de comportement** : sur un install qui n'a rien à faire, il court-circuite et saute les lifecycle scripts.

Vérifié sur un projet témoin minimal :

| | install initial | install no-op |
|---|---|---|
| pnpm 10.29.3 | `prepare` exécuté | `prepare` **exécuté** |
| pnpm 11.16.0 | `prepare` exécuté | `prepare` **sauté** |

Vercel restaure `node_modules` depuis son cache de build. Donc tout commit ne modifiant ni `package.json` ni `pnpm-lock.yaml` produit un install no-op, `prepare` ne tourne pas, et le build démarre sans `styled-system/`.

Le motif colle exactement à l'historique : les commits touchant `package.json` ou le lockfile (#583, #584, #589) sont passés, ceux n'y touchant pas (#585, #588) ont échoué. Un commit de forme identique en mars, sous pnpm 10, était passé.

Régression introduite par le passage à pnpm 11 (#584).

## Le correctif

```diff
-"build": "astro build",
+"build": "panda codegen && astro build",
```

Le build devient auto-suffisant au lieu de dépendre d'un effet de bord de l'install. `prepare` reste en place pour le confort local après un install frais.

## Validation

Reproduit puis vérifié dans les conditions exactes de l'échec : `node_modules` présent, install confirmé no-op (`Already up to date`, pas de `prepare`), `styled-system/` absent. Le build échouait avant, il passe après.

Lint, typecheck et les 11 tests Playwright passent.